### PR TITLE
Fixes #4

### DIFF
--- a/entrypoints/download-button.content/index.tsx
+++ b/entrypoints/download-button.content/index.tsx
@@ -167,6 +167,14 @@ export default defineContentScript({
             anchor: element,
             append: "last",
             onMount: (container) => {
+              const style = document.createElement('style');
+              style.textContent = `
+                button { margin-top: 0 !important; }
+                div { line-height: normal !important; }
+                body { height: auto !important; }
+              `;
+              container.append(style);
+
               const app = document.createElement("div");
               container.className = cn(
                 "ml-auto w-fit bg-transparent float-right",


### PR DESCRIPTION
Fixes the vertical misalignment of the download button by injecting CSS into the shadow DOM to override default styling that pushes the button down.
Before:
<img width="805" height="142" alt="Image" src="https://github.com/user-attachments/assets/0e05857b-9a13-4b47-8639-d7604ed57bc2" />
After:
<img width="713" height="205" alt="obraz" src="https://github.com/user-attachments/assets/afc9100e-c071-4678-9a51-bf7785223e6d" />
