### PR TITLE
feat: support {title} in folder + filename patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ https://github.com/user-attachments/assets/4295d7c0-3b2f-450c-9ec5-53dab86b150d
 
 ### Settings
 
-- **Download Folder**: Where files are saved (supports `{subreddit}` variable)
-- **Filename Pattern**: File naming (supports `{subreddit}`, `{timestamp}`, `{filename}`)
+- **Download Folder**: Where files are saved (supports `{subreddit}`, `{date}`, `{user}`, `{title}`)
+- **Filename Pattern**: File naming (supports `{subreddit}`, `{timestamp}`, `{title}`, `{filename}`)
 - **Gallery Folders**: Separate folders for image galleries
 - **Title Overlay**: Add post titles to media
 

--- a/components/download-button.tsx
+++ b/components/download-button.tsx
@@ -46,14 +46,17 @@ const DownloadButton = ({
       const subredditName = getSubredditNameFromContainer(
         postElement || mediaContainer,
       );
+      // Get post title if needed
+      const postTitle = postElement ? getPostTitle(postElement) : undefined;
+
       const finalFolderDestination = processFolderDestination(
         latestFolderConfig,
         postElement,
         subredditName,
+        undefined,
+        undefined,
+        postTitle,
       );
-
-      // Get post title if needed
-      const postTitle = postElement ? getPostTitle(postElement) : undefined;
 
       // Send message to background script to handle the download
       const downloadResponse = await sendMessage(

--- a/entrypoints/sidepanel/sidebar-app.tsx
+++ b/entrypoints/sidepanel/sidebar-app.tsx
@@ -393,6 +393,7 @@ function SidebarApp() {
               mediaItem.subredditName,
               mediaItem.postDate,
               mediaItem.postAuthor,
+              mediaItem.postTitle,
             );
 
             logger.log(
@@ -684,7 +685,7 @@ function SidebarApp() {
                   />
                 </FormControl>
                 <FormDescription>
-                  Available: {"{subreddit}"}, {"{date}"},
+                  Available: {"{subreddit}"}, {"{date}"}, {"{title}"},
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>
@@ -721,7 +722,8 @@ function SidebarApp() {
                   />
                 </FormControl>
                 <FormDescription>
-                  Available: {"{subreddit}"}, {"{timestamp}"}, {"{filename}"}
+                  Available: {"{subreddit}"}, {"{timestamp}"}, {"{title}"},{" "}
+                  {"{filename}"}
                 </FormDescription>
                 <FormMessage />
               </FormItem>

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "es-toolkit": "^1.39.10",
+    "filenamify": "^7.0.1",
     "radix-ui": "^1.4.3",
     "react": "19.2.0",
     "react-day-picker": "^9.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       es-toolkit:
         specifier: ^1.39.10
         version: 1.39.10
+      filenamify:
+        specifier: ^7.0.1
+        version: 7.0.1
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -2142,6 +2145,14 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  filename-reserved-regex@4.0.0:
+    resolution: {integrity: sha512-9ZT504KxEQDamsOogZImAWGEN24R1uFAxU3ZS4AZqn2ooidmN68Olh7n4/RcA4lLatZztjA0ZSuxeLHVoCc8JA==}
+    engines: {node: '>=20'}
+
+  filenamify@7.0.1:
+    resolution: {integrity: sha512-9b4rfnaX2MkJCgp27wypV6DAMvj4WMOSgJ+TdcpJIO84Dql+Cv6iJjdG4XDTLubOWkfNiBv3joO59sau/TXw+Q==}
+    engines: {node: '>=20'}
 
   filesize@11.0.13:
     resolution: {integrity: sha512-mYJ/qXKvREuO0uH8LTQJ6v7GsUvVOguqxg2VTwQUkyTPXXRRWPdjuUPVqdBrJQhvci48OHlNGRnux+Slr2Rnvw==}
@@ -5232,6 +5243,12 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  filename-reserved-regex@4.0.0: {}
+
+  filenamify@7.0.1:
+    dependencies:
+      filename-reserved-regex: 4.0.0
 
   filesize@11.0.13: {}
 

--- a/utils/filename-utils.ts
+++ b/utils/filename-utils.ts
@@ -1,15 +1,34 @@
+import filenamify from "filenamify/browser";
+
 export interface FilenameData {
   subreddit: string;
   timestamp: string;
   filename: string;
   extension: string;
+  title?: string;
+}
+
+/**
+ * Strip filesystem-unsafe characters from a string so it's safe to use as a filename
+ */
+export function sanitizeForFilename(
+  raw: string | undefined | null,
+  maxLength = 80,
+): string {
+  if (!raw) return "";
+  const cleaned = filenamify(raw, { maxLength, replacement: " " })
+    .replace(/\s+/g, " ")
+    .trim();
+  return cleaned;
 }
 
 export function generateFilename(pattern: string, data: FilenameData): string {
+  const safeTitle = sanitizeForFilename(data.title) || "untitled";
   return (
     pattern
       .replace(/{subreddit}/g, data.subreddit)
       .replace(/{timestamp}/g, data.timestamp)
+      .replace(/{title}/g, safeTitle)
       .replace(/{filename}/g, data.filename) +
     "." +
     data.extension

--- a/utils/media-download.ts
+++ b/utils/media-download.ts
@@ -179,6 +179,7 @@ export async function downloadGalleryImages(options: DownloadImageOptions) {
         timestamp: getCurrentTimestamp(),
         filename: extractFilenameFromUrl(url),
         extension,
+        title: postTitle,
       });
 
       // For galleries with folders, add index to filename to avoid conflicts
@@ -250,6 +251,7 @@ export async function downloadVideo(options: DownloadVideoOptions) {
       timestamp: getCurrentTimestamp(),
       filename: extractFilenameFromUrl(url),
       extension,
+      title: postTitle,
     });
 
     // If text overlay is enabled and we have a title, process the video

--- a/utils/post-utils.ts
+++ b/utils/post-utils.ts
@@ -4,6 +4,7 @@
 
 import { format, parseISO, isValid } from "date-fns";
 import { getSubredditNameFromContainer } from "./scraping-utils";
+import { sanitizeForFilename } from "./filename-utils";
 
 /**
  * Extract the post title from a Reddit post element
@@ -88,7 +89,8 @@ export const processFolderDestination = (
   postElement: Element | null,
   subredditName?: string,
   postDate?: string,
-  postAuthor?: string
+  postAuthor?: string,
+  postTitle?: string
 ): string => {
   let finalDestination = folderDestination || "Reddit Downloads";
 
@@ -114,6 +116,14 @@ export const processFolderDestination = (
     const author =
       postAuthor || (postElement ? getPostAuthor(postElement) : "unknown-user");
     finalDestination = finalDestination.replace(/{user}/g, author);
+  }
+
+  // Replace {title} variable
+  if (finalDestination.includes("{title}")) {
+    const rawTitle =
+      postTitle || (postElement ? getPostTitle(postElement) : "");
+    const safeTitle = sanitizeForFilename(rawTitle) || "untitled";
+    finalDestination = finalDestination.replace(/{title}/g, safeTitle);
   }
 
   return finalDestination;


### PR DESCRIPTION
## Summary
- Adds `{title}` as a variable in both the **Download Folder** and **Filename Pattern** settings, mirroring how `{subreddit}` works in both.
- Uses [`filenamify`](https://github.com/sindresorhus/filenamify) (browser entry) for sanitization — handles Windows reserved names (`CON`, `PRN`, etc.), control chars, Unicode bidi marks, trailing dots/spaces, and grapheme-aware truncation. Reddit titles are full of emoji and unicode that a naive regex would mangle.
- Sidebar UI hints + README updated to advertise the new variable.

Closes #22.

## Test plan
- [x] `pnpm dev` — load on a subreddit, set filename pattern to `{title}_{filename}`, click download on a single-image post → file lands with the post title
- [x] Same with a gallery post (multi-image)
- [x] Same with a video post
- [x] Try a post whose title contains emoji / non-ASCII / forbidden chars (`<>:"/\|?*`) → no crash, filename is clean
- [x] Try `{title}` in the folder destination too → folder is created with the sanitized title
- [x] `pnpm zip` + `pnpm zip:firefox` succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)