### PR TITLE
feat: track offscreen download completion

### DIFF
--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -44,8 +44,8 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
-          className
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit max-w-(--radix-tooltip-content-available-width) origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className,
         )}
         {...props}
       >

--- a/entrypoints/offscreen/main.ts
+++ b/entrypoints/offscreen/main.ts
@@ -8,10 +8,12 @@ browser.runtime.onMessage.addListener((message: any) => {
   handleMessages(message);
 });
 
-function handleMessages(message: OffscreenMessage) {
+function handleMessages(message: OffscreenMessage & { downloadId?: string }) {
   if (message?.target !== MESSAGE_TARGET.OFFSCREEN || !message?.type) {
     return;
   }
+
+  const { downloadId } = message;
 
   switch (message.type) {
     case OFFSCREEN_KEYS.DOWNLOAD_VIDEO:
@@ -19,7 +21,7 @@ function handleMessages(message: OffscreenMessage) {
         ...message.data,
         offscreen: true,
       }).then((result) => {
-        sendToBackground(OFFSCREEN_KEYS.DOWNLOAD_VIDEO, result);
+        sendToBackground(OFFSCREEN_KEYS.DOWNLOAD_VIDEO, result, downloadId);
       });
 
       break;
@@ -28,7 +30,7 @@ function handleMessages(message: OffscreenMessage) {
         ...message.data,
         offscreen: true,
       }).then((result) => {
-        sendToBackground(OFFSCREEN_KEYS.DOWNLOAD_IMAGE, result);
+        sendToBackground(OFFSCREEN_KEYS.DOWNLOAD_IMAGE, result, downloadId);
       });
       break;
     default:
@@ -39,10 +41,11 @@ function handleMessages(message: OffscreenMessage) {
   }
 }
 
-function sendToBackground(type: string, data: any) {
+function sendToBackground(type: string, data: any, downloadId?: string) {
   chrome.runtime.sendMessage({
     type,
     target: MESSAGE_TARGET.BACKGROUND,
     data,
+    downloadId,
   });
 }

--- a/entrypoints/sidepanel/sidebar-app.tsx
+++ b/entrypoints/sidepanel/sidebar-app.tsx
@@ -759,8 +759,23 @@ function SidebarApp() {
                     onCheckedChange={field.onChange}
                   />
                 </FormControl>
-                <div className="space-y-1 leading-none">
-                  <FormLabel>Add post title to images</FormLabel>
+                <div className="space-y-1 leading-none flex items-center gap-1.5">
+                  <FormLabel>Embed post title on images</FormLabel>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex text-gray-500 dark:text-gray-400 cursor-help">
+                          <Icon icon="lucide:info" className="size-3.5" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p className="text-xs">
+                          Overlays the post title as a text caption onto the
+                          downloaded image
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
               </FormItem>
             )}
@@ -777,10 +792,23 @@ function SidebarApp() {
                     onCheckedChange={field.onChange}
                   />
                 </FormControl>
-                <div className="space-y-1 leading-none">
-                  <FormLabel>
-                    Add post title to videos (slower processing)
-                  </FormLabel>
+                <div className="space-y-1 leading-none flex items-center gap-1.5">
+                  <FormLabel>Embed post title on videos</FormLabel>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex text-gray-500 dark:text-gray-400 cursor-help">
+                          <Icon icon="lucide:info" className="size-3.5" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p className="text-xs">
+                          Overlays the post title as a text caption onto the
+                          downloaded video. Downloads will be slower.
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
               </FormItem>
             )}

--- a/types.ts
+++ b/types.ts
@@ -26,6 +26,7 @@ export type DownloadImageOptions = {
 export interface BaseMessage {
   target: string;
   type: string;
+  downloadId?: string;
 }
 
 // Offscreen message types

--- a/utils/offscreen-media-download.ts
+++ b/utils/offscreen-media-download.ts
@@ -7,6 +7,11 @@ import { OFFSCREEN_DOCUMENT_PATH } from "@/utils/constants";
 
 declare const self: ServiceWorkerGlobalScope;
 
+const pendingDownloads = new Map<
+  string,
+  { resolve: () => void; reject: (err: any) => void }
+>();
+
 async function hasOffscreenDocument() {
   const contexts = await browser.runtime?.getContexts({
     contextTypes: [browser.runtime.ContextType.OFFSCREEN_DOCUMENT],
@@ -43,11 +48,19 @@ export const offscreenDownloadVideo = async (
   }
   await createOffscreenDocument();
 
+  const downloadId = crypto.randomUUID();
+  const downloadComplete = new Promise<void>((resolve, reject) => {
+    pendingDownloads.set(downloadId, { resolve, reject });
+  });
+
   await browser.runtime.sendMessage({
     type: OFFSCREEN_KEYS.DOWNLOAD_VIDEO,
     target: MESSAGE_TARGET.OFFSCREEN,
     data: options,
+    downloadId,
   });
+
+  await downloadComplete;
 };
 
 export const offscreenDownloadGalleryImages = async (
@@ -59,11 +72,19 @@ export const offscreenDownloadGalleryImages = async (
 
   await createOffscreenDocument();
 
+  const downloadId = crypto.randomUUID();
+  const downloadComplete = new Promise<void>((resolve, reject) => {
+    pendingDownloads.set(downloadId, { resolve, reject });
+  });
+
   await browser.runtime.sendMessage({
     type: OFFSCREEN_KEYS.DOWNLOAD_IMAGE,
     target: MESSAGE_TARGET.OFFSCREEN,
     data: options,
+    downloadId,
   });
+
+  await downloadComplete;
 };
 
 export async function handleOffscreenMessages(message: any) {
@@ -71,28 +92,45 @@ export async function handleOffscreenMessages(message: any) {
     return;
   }
 
-  switch (message.type) {
-    case OFFSCREEN_KEYS.DOWNLOAD_VIDEO:
-      await browser.downloads.download({
-        url: message.data.url,
-        filename: message.data.filename,
-        saveAs: false,
-      });
-      break;
-    case OFFSCREEN_KEYS.DOWNLOAD_IMAGE:
-      await Promise.all(
-        message.data.map((item) =>
-          browser.downloads.download({
-            url: item.url,
-            filename: item.filename,
-            saveAs: false,
-          })
-        )
-      );
-      break;
-    default:
-      console.warn(
-        `Unexpected message received: '${JSON.stringify(message)}'.`
-      );
+  const { downloadId } = message;
+
+  try {
+    switch (message.type) {
+      case OFFSCREEN_KEYS.DOWNLOAD_VIDEO:
+        await browser.downloads.download({
+          url: message.data.url,
+          filename: message.data.filename,
+          saveAs: false,
+        });
+        break;
+      case OFFSCREEN_KEYS.DOWNLOAD_IMAGE:
+        await Promise.all(
+          message.data.map((item: { url: string; filename: string }) =>
+            browser.downloads.download({
+              url: item.url,
+              filename: item.filename,
+              saveAs: false,
+            })
+          )
+        );
+        break;
+      default:
+        console.warn(
+          `Unexpected message received: '${JSON.stringify(message)}'.`
+        );
+        return;
+    }
+
+    if (downloadId) {
+      pendingDownloads.get(downloadId)?.resolve();
+      pendingDownloads.delete(downloadId);
+    }
+  } catch (error) {
+    if (downloadId) {
+      pendingDownloads.get(downloadId)?.reject(error);
+      pendingDownloads.delete(downloadId);
+    } else {
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
Add downloadId-based promise tracking so callers can await offscreen downloads. Improve sidebar labels from "Add post title" to "Embed post title" with info tooltip explanations. Constrain tooltip max-width to available space.