### PR TITLE
1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redditgrab",
   "description": "RedditGrab - Grab images and videos from Reddit posts",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -24,6 +24,17 @@ export default defineConfig({
       "*://*.redgifs.com/*",
       "*://api.redgifs.com/*",
     ],
+    // Explicit Gecko ID avoids Firefox reporting a signed XPI as corrupt when
+    // Guid from AMO API: https://addons.mozilla.org/api/v5/addons/addon/media-downloader-redditgrab/
+    ...(browser === "firefox"
+      ? {
+          browser_specific_settings: {
+            gecko: {
+              id: "{d6ae963b-906b-4ebe-9d91-ef1cb6f770c9}",
+            },
+          },
+        }
+      : {}),
     content_security_policy: {
       extension_pages:
         "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';",


### PR DESCRIPTION
## What's included

- fix: add explicit Gecko extension ID (`{d6ae963b-906b-4ebe-9d91-ef1cb6f770c9}`) to Firefox manifest to prevent signed XPI from being reported as corrupt by Firefox when trying to install manually.